### PR TITLE
Add compact layout mode for small Kindle displays

### DIFF
--- a/css/kindle.css
+++ b/css/kindle.css
@@ -230,7 +230,7 @@ html.night {
 }
 
 .landscape .colTime {
-    font-size: 120px;
+    font-size: 120px;    
     font-weight: bolder;
     font-family: electronicFont;
 }
@@ -249,4 +249,17 @@ html.night {
     font-size: 4rem;
     font-weight: bolder;
     text-align: center;
+}
+
+.compact .forecast {
+    top: 15%;
+}
+
+.compact #sun {
+    bottom: 3rem;
+    font-size: 3rem;
+}
+
+.compact .landscape .colTime {
+    font-size: 8rem;
 }

--- a/index.html
+++ b/index.html
@@ -458,6 +458,11 @@
             setRem("load");
             setNightMode();
 
+            var v = viewport();
+
+            if (Math.min(v.width, v.height) <= 600) {
+                document.documentElement.classList.add("compact");
+            }
             var now = new Date();
             var cleanTime = (new Date()).setHours(4, 0, 0);
             var diff = cleanTime - now;
@@ -489,10 +494,11 @@
 
         function setNightMode() {
             var root = document.querySelector(":root");
+
             if (isNightMode()) {
-                root.className = "night";
+                root.classList.add("night");
             } else {
-                root.className = null;
+                root.classList.remove("night");
             }
         }
 


### PR DESCRIPTION
This PR adds a compact layout mode for devices with small viewport sizes.

Changes:

* Added automatic compact mode detection for small screens.
* Added compact CSS rules to improve layout spacing.
* Reduced overlap between forecast information and footer content.
* Adjusted forecast positioning and time display sizing.
* Updated night mode class handling to allow multiple CSS classes simultaneously.

Tested on:

* Kindle Basic 8th Generation
* Portuguese language
* English language
* Chinese language

Problem:
On smaller Kindle displays, forecast information and footer content could overlap, especially when using languages with longer words.

Result:
The compact mode preserves the original layout on larger devices while improving readability and preventing content overlap on smaller Kindle screens.
<img width="522" height="703" alt="KindleWithaProblemInPt" src="https://github.com/user-attachments/assets/b44867b6-33e3-489a-9f4c-4b513a7b1947" />
<img width="899" height="1599" alt="KindleWithPTCorrection" src="https://github.com/user-attachments/assets/3191841b-c28a-46c6-b0f5-5ce3bf945da9" />
